### PR TITLE
Update Otel-Collector config with resource processor

### DIFF
--- a/WebApi.OpenTelemetry.DataDog/otel-collector-config.yaml
+++ b/WebApi.OpenTelemetry.DataDog/otel-collector-config.yaml
@@ -17,6 +17,11 @@ receivers:
 processors:
   batch:
     timeout: 10s
+  resource:
+    attributes:
+    - key: datadog.host.name
+      value: telemetrylabs
+      action: upsert
     
 exporters:
   datadog/api: 
@@ -34,11 +39,11 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [resource, batch]
       exporters: [datadog/api]
     metrics:
       receivers: [hostmetrics]
-      processors: [batch]
+      processors: [resource, batch]
       exporters: [datadog/api]
 #    logs:
 #      receivers: [otlp]


### PR DESCRIPTION
This PR adds a [resourceprocessor](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/resourceprocessor) to ensure your trace-metric hostnames and opentelemetry metrics have matching hostnames while we work to resolve this without the need for a processor upstream.